### PR TITLE
Fix property name for reload interval

### DIFF
--- a/Entities/SettingsClass.cs
+++ b/Entities/SettingsClass.cs
@@ -13,7 +13,7 @@ public class SettingsClass
     public List<Cookie> Cookies { get; set; }
     public bool IsDebug { get; set; }
     public float CalculateDynamicVariablesInterval { get; set; }
-    public float RealoadPendingCodeReferenceInterval { get; set; }
+    public float ReloadPendingCodeReferenceInterval { get; set; }
     public float ReferenceCodeExpirationTime { get; set; }
     public int ReferenceCodeLength { get; set; }
     public Databases DatabaseConection { get; set; }

--- a/Services/Databases/DatabasesActions.cs
+++ b/Services/Databases/DatabasesActions.cs
@@ -170,7 +170,7 @@ public class DatabasesActions : IDatabasesActions
         {
             try
             {
-                var AllPendingSensors = _Context.Sensors.Where(x => x.LastReferenceChange < DateTime.Now.AddMinutes(-_Settings.RealoadPendingCodeReferenceInterval)).ToList();
+                var AllPendingSensors = _Context.Sensors.Where(x => x.LastReferenceChange < DateTime.Now.AddMinutes(-_Settings.ReloadPendingCodeReferenceInterval)).ToList();
                 if (AllPendingSensors.Any())
                 {
                     foreach (var sensor in AllPendingSensors)
@@ -180,7 +180,7 @@ public class DatabasesActions : IDatabasesActions
                         _Context.Sensors.Update(sensor);
                     }
                 }
-                var AllPendingActuators = _Context.Actuators.Where(x => x.LastReferenceChange < DateTime.Now.AddMinutes(-_Settings.RealoadPendingCodeReferenceInterval)).ToList();
+                var AllPendingActuators = _Context.Actuators.Where(x => x.LastReferenceChange < DateTime.Now.AddMinutes(-_Settings.ReloadPendingCodeReferenceInterval)).ToList();
                 if (AllPendingActuators.Any())
                 {
                     foreach (var actuator in AllPendingActuators)
@@ -212,7 +212,7 @@ public class DatabasesActions : IDatabasesActions
 
                 // Si se respeta el intervalo y todavía no venció, salimos sin cambios
                 if (!ignorarIntervalo &&
-                    sensor.LastReferenceChange >= DateTime.Now.AddMinutes(-_Settings.RealoadPendingCodeReferenceInterval))
+                    sensor.LastReferenceChange >= DateTime.Now.AddMinutes(-_Settings.ReloadPendingCodeReferenceInterval))
                 {
                     return null;
                 }
@@ -246,7 +246,7 @@ public class DatabasesActions : IDatabasesActions
 
                 // Si se respeta el intervalo y todavía no venció, salimos sin cambios
                 if (!ignorarIntervalo &&
-                    Actuator.LastReferenceChange >= DateTime.Now.AddMinutes(-_Settings.RealoadPendingCodeReferenceInterval))
+                    Actuator.LastReferenceChange >= DateTime.Now.AddMinutes(-_Settings.ReloadPendingCodeReferenceInterval))
                 {
                     return null;
                 }

--- a/Services/SensorsAndActuators/ChangeReferenceCodeTimer.cs
+++ b/Services/SensorsAndActuators/ChangeReferenceCodeTimer.cs
@@ -26,7 +26,7 @@ public class ChangeReferenceCodeTimer : IHostedService
     public Task StartAsync(CancellationToken cancellationToken)
     {
         UpdateSettings();
-        _timer = new Timer(ChangeReferenceCode, null, TimeSpan.FromSeconds(15), TimeSpan.FromMinutes(_Settings.RealoadPendingCodeReferenceInterval));
+        _timer = new Timer(ChangeReferenceCode, null, TimeSpan.FromSeconds(15), TimeSpan.FromMinutes(_Settings.ReloadPendingCodeReferenceInterval));
         return Task.CompletedTask;
     }
     public Task StopAsync(CancellationToken cancellationToken)
@@ -46,6 +46,6 @@ public class ChangeReferenceCodeTimer : IHostedService
     }
     void ResetTimer()
     {
-        _timer.Change(TimeSpan.FromMinutes(_Settings.RealoadPendingCodeReferenceInterval), TimeSpan.FromMinutes(_Settings.RealoadPendingCodeReferenceInterval));
+        _timer.Change(TimeSpan.FromMinutes(_Settings.ReloadPendingCodeReferenceInterval), TimeSpan.FromMinutes(_Settings.ReloadPendingCodeReferenceInterval));
     }
 }

--- a/Testing/Data/Settings
+++ b/Testing/Data/Settings
@@ -8,7 +8,7 @@
   ],
   "IsDebug": false,
   "CalculateDynamicVariablesInterval": -1.0,
-  "RealoadPendingCodeReferenceInterval": 10080.0,
+  "ReloadPendingCodeReferenceInterval": 10080.0,
   "ReferenceCodeExpirationTime": 10080.0,
   "ReferenceCodeLength": 8,
   "DatabaseConection": {


### PR DESCRIPTION
## Summary
- rename `RealoadPendingCodeReferenceInterval` to `ReloadPendingCodeReferenceInterval`
- update usages in database actions and timers
- sync testing settings file

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a09235d18832a9f13fd3c5abe3fda