### PR TITLE
Implement API token authentication

### DIFF
--- a/Data/DatabasesTablesContext.cs
+++ b/Data/DatabasesTablesContext.cs
@@ -114,6 +114,7 @@ public class DatabaseContext : DbContext
             entity.Property(e => e.UserName)  .HasColumnName("username");
             entity.Property(e => e.Email)     .HasColumnName("email");
             entity.Property(e => e.Password)  .HasColumnName("password");
+            entity.Property(e => e.ApiToken)  .HasColumnName("api_token");
             entity.Property(e => e.CreatedAt) .HasColumnName("created_at");
         });
 

--- a/Entities/DatabasesTablesClases.cs
+++ b/Entities/DatabasesTablesClases.cs
@@ -113,6 +113,7 @@ public class User
     public string UserName { get; set; } = null!;
     public string Email { get; set; } = null!;
     public string Password { get; set; } = null!;
+    public string ApiToken { get; set; } = null!; // Token to authenticate API requests
     public DateTime CreatedAt { get; set; }
 }
 public class Group

--- a/Services/Users/Users.cs
+++ b/Services/Users/Users.cs
@@ -56,6 +56,7 @@ public class Users : IUsers
             UserName = NewUser.RegisteUsername,
             Email = NewUser.RegisterEmail,
             Password = NewUser.RegisterPassword,
+            ApiToken = _databasesActions.GenerateUniqueUserApiToken(),
             CreatedAt = DateTime.Now
         });
 
@@ -148,6 +149,11 @@ public class Users : IUsers
         {LoginErrorMessages.NotInsertedPassword, "web.auth.login.notinsertedpassword" },//"NotInsertedPassword" },
         {LoginErrorMessages.PasswordIsIncorrect, "web.auth.login.passwordisincorrect" },//"PasswordIsIncorrect" }
     };
+
+    public User? GetUserByApiToken(string apiToken)
+    {
+        return _databasesActions.GetUserByApiToken(apiToken);
+    }
 }
 public interface IUsers
 {
@@ -156,6 +162,7 @@ public interface IUsers
 
     public Task<List<(LoginErrorMessages Error, string message)>> LoginUser(IUsers.LoginFormModel LoginForm);
     List<LoginErrorMessages> CheckLoginUser(IUsers.LoginFormModel LoginForm);
+    User? GetUserByApiToken(string apiToken);
 
     public class RegisterFormModel
     {

--- a/Services/Web/Auth/ApiTokenAuthenticationAttribute.cs
+++ b/Services/Web/Auth/ApiTokenAuthenticationAttribute.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Services.Users;
+
+namespace Services.Web.Auth;
+
+public class ApiTokenAuthenticationAttribute : Attribute, IAsyncActionFilter
+{
+    private const string HeaderName = "X-Api-Token";
+
+    public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(HeaderName, out var token))
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        var userService = context.HttpContext.RequestServices.GetService<IUsers>();
+        var user = userService?.GetUserByApiToken(token!);
+        if (user == null)
+        {
+            context.Result = new UnauthorizedResult();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/Web/Controllers/Actuator.cs
+++ b/Web/Controllers/Actuator.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Services.Administrate;
 using Services.SensorsAndActuators;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -9,6 +10,7 @@ namespace Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class Actuator : ControllerBase
 {
     private readonly IActuators _Actuators;

--- a/Web/Controllers/Administrate/AdministrateActuators.cs
+++ b/Web/Controllers/Administrate/AdministrateActuators.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class AdministrateActuators : ControllerBase
 {
     private readonly Services.Administrate.IActuator _AdministrateActuator;

--- a/Web/Controllers/Administrate/AdministrateLocations.cs
+++ b/Web/Controllers/Administrate/AdministrateLocations.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class AdministrateLocations : ControllerBase
 {
     private readonly Services.Administrate.ILocation _location;

--- a/Web/Controllers/Administrate/AdministrateSensors.cs
+++ b/Web/Controllers/Administrate/AdministrateSensors.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class AdministrateSensors : ControllerBase
 {
     private readonly Services.Administrate.ISensor _sensor;

--- a/Web/Controllers/Administrate/AdministrateUsers.cs
+++ b/Web/Controllers/Administrate/AdministrateUsers.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class AdministrateUsers : ControllerBase
 {
     private readonly Services.Administrate.IUser _user;

--- a/Web/Controllers/Administrate/AdministrateVariables.cs
+++ b/Web/Controllers/Administrate/AdministrateVariables.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/AdministrateVariables")]
 [ApiController]
+[ApiTokenAuthentication]
 public class AdministrateVariables : ControllerBase
 {
     private readonly Services.Administrate.IVariable _variable;

--- a/Web/Controllers/Sensors.cs
+++ b/Web/Controllers/Sensors.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Services.Web.Auth;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -6,6 +7,7 @@ namespace Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
+[ApiTokenAuthentication]
 public class Sensors : ControllerBase
 {
     private readonly Services.SensorsAndActuators.ISensors _sensor;


### PR DESCRIPTION
## Summary
- add `ApiToken` field to `User` entity and map in DB context
- ensure token generator checks against user tokens
- generate API token on user creation
- expose lookup by API token in `IDatabasesActions` and `IUsers`
- create `ApiTokenAuthenticationAttribute` filter
- require API token in `Sensors` controller

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a18b5c604832a983cfbc0042790b6