### PR TITLE
Add basic event system

### DIFF
--- a/Data/DatabasesTablesContext.cs
+++ b/Data/DatabasesTablesContext.cs
@@ -28,6 +28,7 @@ public class DatabaseContext : DbContext
     public DbSet<Variable>      Variables      => Set<Variable>();
     public DbSet<Language> Languages => Set<Language>();
     public DbSet<Traduction> Translations => Set<Traduction>();
+    public DbSet<Event> Events => Set<Event>();
 
 
 
@@ -241,6 +242,26 @@ public class DatabaseContext : DbContext
             entity.Property(e => e.LanguageId)         .HasColumnName("language_id");
             entity.Property(e => e.TraductionReference).HasColumnName("traduction_reference");
             entity.Property(e => e.Value)              .HasColumnName("value");
+        });
+
+        // ——— EVENTS ————————————————————————
+        modelBuilder.Entity<Event>(entity =>
+        {
+            entity.ToTable("events");
+            entity.HasKey(e => e.EventId);
+
+            entity.Property(e => e.EventId)        .HasColumnName("event_id");
+            entity.Property(e => e.Name)           .HasColumnName("name");
+            entity.Property(e => e.OwnerId)        .HasColumnName("owner_id");
+            entity.Property(e => e.Actions)        .HasColumnName("actions");
+            entity.Property(e => e.Condition)      .HasColumnName("condition");
+            entity.Property(e => e.IntervalMinutes).HasColumnName("interval_minutes");
+            entity.Property(e => e.ScheduledTime)  .HasColumnName("scheduled_time");
+            entity.Property(e => e.IsEnabled)      .HasColumnName("is_enabled");
+            entity.Property(e => e.CreatedAt)      .HasColumnName("created_at");
+            entity.Property(e => e.LastExecutedAt) .HasColumnName("last_executed_at");
+
+            entity.HasOne<User>().WithMany().HasForeignKey(e => e.OwnerId);
         });
     }
 }

--- a/Entities/DatabasesTablesClases.cs
+++ b/Entities/DatabasesTablesClases.cs
@@ -252,3 +252,17 @@ public class Traduction
     public int LanguageId { get; set; }
     public string Value { get; set; }
 }
+
+public class Event
+{
+    public int EventId { get; set; }
+    public string Name { get; set; } = null!;
+    public int OwnerId { get; set; }
+    public string Actions { get; set; } = null!;
+    public string? Condition { get; set; }
+    public double? IntervalMinutes { get; set; }
+    public TimeSpan? ScheduledTime { get; set; }
+    public bool IsEnabled { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? LastExecutedAt { get; set; }
+}

--- a/Entities/SettingsClass.cs
+++ b/Entities/SettingsClass.cs
@@ -16,6 +16,7 @@ public class SettingsClass
     public float ReloadPendingCodeReferenceInterval { get; set; }
     public float ReferenceCodeExpirationTime { get; set; }
     public int ReferenceCodeLength { get; set; }
+    public float EventsCheckInterval { get; set; }
     public Databases DatabaseConection { get; set; }
 
 

--- a/Services/Databases/DatabasesActions.cs
+++ b/Services/Databases/DatabasesActions.cs
@@ -562,6 +562,54 @@ public class DatabasesActions : IDatabasesActions
     }
     #endregion
 
+    //Events
+    #region Events
+    public List<Event> GetEvents(Event filter)
+    {
+        return ExecuteReadWithRetry(() =>
+        {
+            var query = _Context.Events.AsNoTracking().AsQueryable();
+            if (filter.EventId != 0) query = query.Where(x => x.EventId == filter.EventId);
+            if (!string.IsNullOrEmpty(filter.Name)) query = query.Where(x => x.Name == filter.Name);
+            if (filter.OwnerId != 0) query = query.Where(x => x.OwnerId == filter.OwnerId);
+            if (filter.IsEnabled) query = query.Where(x => x.IsEnabled == filter.IsEnabled);
+            return query.ToList();
+        });
+    }
+
+    public void CreateEvent(Event ev)
+    {
+        ExecuteWithRetry(() =>
+        {
+            ev.CreatedAt = DateTime.UtcNow;
+            _Context.Events.Add(ev);
+            _Context.SaveChanges();
+        });
+    }
+
+    public void UpdateEvent(Event ev)
+    {
+        ExecuteWithRetry(() =>
+        {
+            _Context.Events.Update(ev);
+            _Context.SaveChanges();
+        });
+    }
+
+    public void DeleteEvent(int eventId)
+    {
+        ExecuteWithRetry(() =>
+        {
+            var ev = _Context.Events.FirstOrDefault(e => e.EventId == eventId);
+            if (ev != null)
+            {
+                _Context.Events.Remove(ev);
+                _Context.SaveChanges();
+            }
+        });
+    }
+    #endregion
+
 
 
     //Other
@@ -662,4 +710,10 @@ public interface IDatabasesActions
 
     //Traductions
     string GetTraduction(string Key, int languageId);
+
+    //Events
+    List<Event> GetEvents(Event filter);
+    void CreateEvent(Event ev);
+    void UpdateEvent(Event ev);
+    void DeleteEvent(int eventId);
 }

--- a/Services/Events/EventExecutor.cs
+++ b/Services/Events/EventExecutor.cs
@@ -1,0 +1,93 @@
+using System.Text.RegularExpressions;
+using System.Linq;
+using Entities;
+using NCalc;
+using Services.Databases;
+using Services.Variables;
+using Microsoft.Extensions.Logging;
+
+namespace Services.Events;
+
+public class EventExecutor : IEventExecutor
+{
+    private readonly IDatabasesActions _database;
+    private readonly IGeneralVariables _variables;
+    private readonly ILogger<EventExecutor> _logger;
+
+    public EventExecutor(IDatabasesActions database, IGeneralVariables variables, ILogger<EventExecutor> logger)
+    {
+        _database = database;
+        _variables = variables;
+        _logger = logger;
+    }
+
+    public void ExecuteEvent(Event ev)
+    {
+        if (!ev.IsEnabled) return;
+
+        if (!string.IsNullOrEmpty(ev.Condition))
+        {
+            var expression = new Expression(ev.Condition);
+            foreach (var param in ExtractParameterNames(ev.Condition))
+            {
+                int vid = int.Parse(param.Substring(1));
+                expression.Parameters[param] = _variables.GetVariableState(vid);
+            }
+            try
+            {
+                var result = expression.Evaluate();
+                if (!(result is bool b ? b : Convert.ToBoolean(result)))
+                    return;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error evaluating event condition {Name}", ev.Name);
+                return;
+            }
+        }
+
+        ExecuteActions(ev.Actions);
+        ev.LastExecutedAt = DateTime.UtcNow;
+        _database.UpdateEvent(ev);
+    }
+
+    private void ExecuteActions(string actions)
+    {
+        if (string.IsNullOrWhiteSpace(actions)) return;
+        foreach (var action in actions.Split(';', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = action.Split('=', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2) continue;
+            var target = parts[0].Trim();
+            var expressionString = parts[1];
+            if (!target.StartsWith("[v") || !target.EndsWith("]")) continue;
+            int vid = int.Parse(target.Trim('[', 'v', ']'));
+            var expression = new Expression(expressionString);
+            foreach (var param in ExtractParameterNames(expressionString))
+            {
+                int pvid = int.Parse(param.Substring(1));
+                expression.Parameters[param] = _variables.GetVariableState(pvid);
+            }
+            try
+            {
+                var result = expression.Evaluate();
+                _variables.UpdateVariableValue(vid, result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error executing action {Action}", action);
+            }
+        }
+    }
+
+    private static List<string> ExtractParameterNames(string formula)
+    {
+        var matches = Regex.Matches(formula, @"\[v[0-9]+\]");
+        return matches.Select(m => m.Value.Trim('[', ']')).Distinct().ToList();
+    }
+}
+
+public interface IEventExecutor
+{
+    void ExecuteEvent(Event ev);
+}

--- a/Services/Events/EventsTimer.cs
+++ b/Services/Events/EventsTimer.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Threading;
+using Entities;
+using Microsoft.Extensions.Hosting;
+using Services.Databases;
+using Services.GeneralFunctions.Settings;
+
+namespace Services.Events;
+
+public class EventsTimer : IHostedService
+{
+    private readonly IEventExecutor _executor;
+    private readonly IDatabasesActions _database;
+    private readonly ISettings _settingsActions;
+    private SettingsClass _settings;
+    private Timer _timer;
+
+    public EventsTimer(IEventExecutor executor, IDatabasesActions database, ISettings settings)
+    {
+        _executor = executor;
+        _database = database;
+        _settingsActions = settings;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _timer = new Timer(Work, null, TimeSpan.Zero, TimeSpan.Zero);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer?.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private void Work(object state)
+    {
+        ReloadSettings();
+        if (_settings.EventsCheckInterval <= 0)
+            return;
+
+        var events = _database.GetEvents(new Event());
+        foreach (var ev in events)
+        {
+            if (!ev.IsEnabled) continue;
+            bool shouldRun = false;
+            var now = DateTime.UtcNow;
+            if (ev.IntervalMinutes.HasValue && ev.IntervalMinutes.Value > 0)
+            {
+                if (!ev.LastExecutedAt.HasValue || (now - ev.LastExecutedAt.Value).TotalMinutes >= ev.IntervalMinutes.Value)
+                    shouldRun = true;
+            }
+            if (ev.ScheduledTime.HasValue)
+            {
+                var todayExecution = DateTime.UtcNow.Date + ev.ScheduledTime.Value;
+                if (now >= todayExecution && (!ev.LastExecutedAt.HasValue || ev.LastExecutedAt.Value < todayExecution))
+                    shouldRun = true;
+            }
+            if (shouldRun)
+            {
+                _executor.ExecuteEvent(ev);
+            }
+        }
+    }
+
+    private void ReloadSettings()
+    {
+        _settings = _settingsActions.ReadSettings();
+        if (_settings.EventsCheckInterval > 0)
+        {
+            _timer.Change(TimeSpan.FromMinutes(_settings.EventsCheckInterval), TimeSpan.FromMinutes(_settings.EventsCheckInterval));
+        }
+        else
+        {
+            _timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+        }
+    }
+}

--- a/Testing/Data/Settings
+++ b/Testing/Data/Settings
@@ -11,6 +11,7 @@
   "ReloadPendingCodeReferenceInterval": 10080.0,
   "ReferenceCodeExpirationTime": 10080.0,
   "ReferenceCodeLength": 8,
+  "EventsCheckInterval": -1.0,
   "DatabaseConection": {
     "DatabaseName": "iot",
     "DatabaseUser": "Server",

--- a/Web/Controllers/Events.cs
+++ b/Web/Controllers/Events.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Services.Events;
+using Services.Web.Auth;
+
+namespace Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[ApiTokenAuthentication]
+public class Events : ControllerBase
+{
+    private readonly IEventExecutor _executor;
+    private readonly Services.Databases.IDatabasesActions _db;
+
+    public Events(IEventExecutor executor, Services.Databases.IDatabasesActions db)
+    {
+        _executor = executor;
+        _db = db;
+    }
+
+    [HttpPost("Execute/{id:int}")]
+    public IActionResult Execute(int id)
+    {
+        var ev = _db.GetEvents(new Entities.Event { EventId = id }).FirstOrDefault();
+        if (ev == null) return NotFound();
+        _executor.ExecuteEvent(ev);
+        return Ok();
+    }
+}

--- a/Web/Program.cs
+++ b/Web/Program.cs
@@ -8,6 +8,7 @@ using Services.Traductions;
 using Services.Variables;
 using Web.Cookies;
 using Services.Administrate;
+using Services.Events;
 using Services.Users;
 using Services.GeneralFunctions.Logger;
 using Services.Web.Cookies;
@@ -27,7 +28,7 @@ internal class Program
         builder.Services.AddControllers();
 
 
-        // Configurar autenticación con cookies
+        // Configurar autenticaciÃ³n con cookies
         builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
             .AddCookie(options =>
             {
@@ -82,7 +83,9 @@ internal class Program
         builder.Services.AddSingleton<IFileFunctions, FileFunctions>();
         builder.Services.AddSingleton<Services.GeneralFunctions.Logger.ILogger, Logger>();
 
-        // Registro de ISensors con su implementación Sensors
+        builder.Services.AddSingleton<IEventExecutor, EventExecutor>();
+        builder.Services.AddSingleton<IHostedService, EventsTimer>();
+        // Registro de ISensors con su implementaciÃ³n Sensors
         builder.Services.AddSingleton<IGeneralVariables, GeneralVariables>();
         builder.Services.AddSingleton<ICalculateDynamicVariables, CalculateDynamicVariables>();
         builder.Services.AddSingleton<ISensors, Sensors>();


### PR DESCRIPTION
## Summary
- introduce `Event` entity and database mapping
- extend settings with event interval configuration
- implement `EventExecutor` and `EventsTimer` services
- add API controller to execute events on demand
- register new services in web startup

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ff7a610832a9ff3d3dba2fecacc