### PR TITLE
Implement Events API controller

### DIFF
--- a/Web/Controllers/Events.cs
+++ b/Web/Controllers/Events.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using Services.Events;
+using Services.Web.Auth;
+
+namespace Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[ApiTokenAuthentication]
+public class Events : ControllerBase
+{
+    private readonly IEvents _eventsService;
+
+    public Events(IEvents eventsService)
+    {
+        _eventsService = eventsService;
+    }
+
+    [HttpPost("{eventId}/execute")]
+    public IActionResult Execute(int eventId)
+    {
+        _eventsService.TriggerEvent(eventId);
+        return Ok();
+    }
+}


### PR DESCRIPTION
## Summary
- add new controller `Events` to expose HTTP endpoint for executing events

## Testing
- `dotnet build Web/Web.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a85c16c832a91fe20da40c55375