### PR TITLE
Implement Events API controller

### DIFF
--- a/Services/Web/Auth/JwtTokenBuilder.cs
+++ b/Services/Web/Auth/JwtTokenBuilder.cs
@@ -1,0 +1,37 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Services.Web.Auth;
+
+public interface IJwtTokenBuilder
+{
+    string BuildJwt(IEnumerable<Claim> claims, string audience);
+}
+
+public class JwtTokenBuilder : IJwtTokenBuilder
+{
+    private readonly IConfiguration _config;
+
+    public JwtTokenBuilder(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    public string BuildJwt(IEnumerable<Claim> claims, string audience)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var token = new JwtSecurityToken(
+            issuer: _config["Jwt:Issuer"],
+            audience: audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddMinutes(30),
+            signingCredentials: creds);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/Web/Controllers/Actuator.cs
+++ b/Web/Controllers/Actuator.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Services.Administrate;
 using Services.SensorsAndActuators;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -10,7 +11,7 @@ namespace Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Devices")]
 public class Actuator : ControllerBase
 {
     private readonly IActuators _Actuators;

--- a/Web/Controllers/Administrate/AdministrateActuators.cs
+++ b/Web/Controllers/Administrate/AdministrateActuators.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Administrate")]
 public class AdministrateActuators : ControllerBase
 {
     private readonly Services.Administrate.IActuator _AdministrateActuator;

--- a/Web/Controllers/Administrate/AdministrateLocations.cs
+++ b/Web/Controllers/Administrate/AdministrateLocations.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Administrate")]
 public class AdministrateLocations : ControllerBase
 {
     private readonly Services.Administrate.ILocation _location;

--- a/Web/Controllers/Administrate/AdministrateSensors.cs
+++ b/Web/Controllers/Administrate/AdministrateSensors.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Administrate")]
 public class AdministrateSensors : ControllerBase
 {
     private readonly Services.Administrate.ISensor _sensor;

--- a/Web/Controllers/Administrate/AdministrateUsers.cs
+++ b/Web/Controllers/Administrate/AdministrateUsers.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Administrate")]
 public class AdministrateUsers : ControllerBase
 {
     private readonly Services.Administrate.IUser _user;

--- a/Web/Controllers/Administrate/AdministrateVariables.cs
+++ b/Web/Controllers/Administrate/AdministrateVariables.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers.Administrate;
 
 [Route("api/AdministrateVariables")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Administrate")]
 public class AdministrateVariables : ControllerBase
 {
     private readonly Services.Administrate.IVariable _variable;

--- a/Web/Controllers/Events.cs
+++ b/Web/Controllers/Events.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc;
+using Services.Events;
+using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Authorize(AuthenticationSchemes = "Events")]
+public class Events : ControllerBase
+{
+    private readonly IEvents _eventsService;
+
+    public Events(IEvents eventsService)
+    {
+        _eventsService = eventsService;
+    }
+
+    [HttpPost("{eventId}/execute")]
+    public IActionResult Execute(int eventId)
+    {
+        _eventsService.TriggerEvent(eventId);
+        return Ok();
+    }
+}

--- a/Web/Controllers/Sensors.cs
+++ b/Web/Controllers/Sensors.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Services.Web.Auth;
+using Microsoft.AspNetCore.Authorization;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -7,7 +8,7 @@ namespace Api.Controllers;
 
 [Route("api/[controller]")]
 [ApiController]
-[ApiTokenAuthentication]
+[Authorize(AuthenticationSchemes = "Devices")]
 public class Sensors : ControllerBase
 {
     private readonly Services.SensorsAndActuators.ISensors _sensor;

--- a/Web/appsettings.json
+++ b/Web/appsettings.json
@@ -6,4 +6,10 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "Jwt": {
+    "Key": "llave-super-secreta-32+ch",
+    "Issuer": "https://auth.ventaclick.com",
+    "Audiences": "events-api,administrate-api,devices-api"
+  }
 }


### PR DESCRIPTION
## Summary
- add JWT auth configuration with multiple schemes
- add `JwtTokenBuilder` helper to issue JWT tokens
- secure API controllers with `[Authorize]` by scheme

## Testing
- `dotnet build Web/Web.csproj -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b6a85c16c832a91fe20da40c55375