### PR TITLE
Handle SignalR reconnects

### DIFF
--- a/Services/SignalR/Client/ClientSignalRRequestManager.cs
+++ b/Services/SignalR/Client/ClientSignalRRequestManager.cs
@@ -71,7 +71,6 @@ public class ClientSignalRRequestManager : IClientSignalRRequestManager
         if (!TokensPins.ContainsKey(token))
         {
             TokensPins.Add(token, pin);
-            ClientSignalRConnetionManager.HubConnection.SendAsync("SetUpCredentials", token).Wait();
         }
     }
 
@@ -82,10 +81,8 @@ public class ClientSignalRRequestManager : IClientSignalRRequestManager
         {
             foreach (var device in devices)
             {
-                if (!TokensPins.ContainsKey(device.Token))
-                {
-                    AddTokenPin(device.Token, device.Pin);
-                }
+                AddTokenPin(device.Token, device.Pin);
+                ClientSignalRConnetionManager.HubConnection.SendAsync("SetUpCredentials", device.Token).Wait();
             }
         }
         else

--- a/Services/SignalR/Server/SignalRHub.cs
+++ b/Services/SignalR/Server/SignalRHub.cs
@@ -30,6 +30,7 @@ public class SignalRHub : Hub
     {
         // You can add logic here when a client disconnects
         Console.WriteLine($"Client disconnected: {Context.ConnectionId}");
+        _manageConnections.RemoveConnection(Context.ConnectionId);
         return base.OnDisconnectedAsync(exception);
     }
 


### PR DESCRIPTION
## Summary
- clear disconnected connection from manager
- resend credentials for all known tokens on reconnect

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd5870fac832abae1845c6ee547ca